### PR TITLE
The 'cache' option takes Int, not Bool

### DIFF
--- a/lib/Catalyst/View/Xslate.pm
+++ b/lib/Catalyst/View/Xslate.pm
@@ -44,7 +44,7 @@ has cache_dir => (
 
 has cache => (
     is => 'rw',
-    isa => 'Bool',
+    isa => 'Int',
     default => 1,
     trigger => $clearer,
 );


### PR DESCRIPTION
Cache option should accept Int for 0, 1, 2 as Xslate does.

cf. http://twitter.com/#!/__travail__/status/35657930531536896
