### PR TITLE
Fixup repo and compatiblity with upcoming catalyst

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Changes
 =======
 
+0.00017 - 28 Feb 2013
+    * Merge pullreq #17: Check passed parameters are defined, not for their
+      boolean values (wreis)
+    * Merge pullreq #18: Add type attribute (wreis)
+
 0.00016 - 17 Oct 2012
     * Merge pullreq #16: Add a build_expose_method (wreis)
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Changes
 =======
 
+0.00018 - 03 Jan 2015
+    * compatibility shim added to test cases so that the encoding tests will
+      pass with Catalyst v 5.90080+
+    * Documentation on UTF8 and default encoding on new Catalyst.
+    * Updated copyeright notices
+
 0.00017 - 28 Feb 2013
     * Merge pullreq #17: Check passed parameters are defined, not for their
       boolean values (wreis)

--- a/lib/Catalyst/View/Xslate.pm
+++ b/lib/Catalyst/View/Xslate.pm
@@ -7,7 +7,7 @@ use namespace::autoclean;
 use Scalar::Util qw/blessed weaken/;
 use File::Find ();
 
-our $VERSION = '0.00017';
+our $VERSION = '0.00018';
 
 extends 'Catalyst::View';
 
@@ -320,6 +320,15 @@ The charset used to output the response body. The value defaults to 'UTF-8'.
 By default, output will be encoded to C<content_charset>.
 You can set it to 0 to disable this behavior.
 (you need to do this if you're using C<Catalyst::Plugin::Unicode::Encoding>)
+
+B<NOTE> Starting with L<Catalyst> version 5.90080 Catalyst will automatically
+encode to UTF8 any text like body responses.  You should either turn off the
+body encoding step in this view using this attribute OR disable this feature
+in the application (your subclass of Catalyst.pm).
+
+    MyApp->config(encoding => undef);
+
+Failure to do so will result in double encoding.
 
 =head2 Text::Xslate CONFIGURATION
 

--- a/lib/Catalyst/View/Xslate.pm
+++ b/lib/Catalyst/View/Xslate.pm
@@ -7,7 +7,7 @@ use namespace::autoclean;
 use Scalar::Util qw/blessed weaken/;
 use File::Find ();
 
-our $VERSION = '0.00016';
+our $VERSION = '0.00017';
 
 extends 'Catalyst::View';
 

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -9,6 +9,7 @@ __PACKAGE__->config(
     name                  => 'TestApp',
     default_message       => 'hi',
     default_view          => 'Xslate::Pkgconfig',
+    encoding => undef
 );
 
 __PACKAGE__->setup;

--- a/t/root/heart.tx
+++ b/t/root/heart.tx
@@ -1,0 +1,1 @@
+<p>This heart literal ♥</p><p>This is heart var <: $hearts :></p>

--- a/t/utf8.t
+++ b/t/utf8.t
@@ -1,0 +1,52 @@
+use utf8;
+use warnings;
+use strict;
+use Test::More;
+use Encode 2.21 'decode_utf8';
+use File::Spec;
+use Cwd;
+
+{
+  package MyApp;
+  $INC{'MyApp.pm'} = __FILE__;
+
+  use Catalyst;
+
+  package MyApp::Controller::Root;
+  $INC{'MyApp/Controller/Root.pm'} = __FILE__;
+
+  use base 'Catalyst::Controller';
+
+  sub heart :Path('♥') {
+    my ($self, $c) = @_;
+    $c->stash(hearts=>'♥♥♥');
+    $c->res->content_type('text/html');
+    $c->detach('View::HTML');
+  }
+  package MyApp::View::HTML;
+  $INC{'MyApp/View/HTML.pm'} = __FILE__;
+
+  use base 'Catalyst::View::Xslate';
+
+  MyApp::View::HTML->config(
+    encode_body => 0,
+    encoding => 'UTF-8',
+    path => [Cwd::abs_path(MyApp->path_to('t'))],
+  );
+
+  MyApp->setup;
+}
+
+use Catalyst::Test 'MyApp';
+
+if(MyApp->can('encoding') and MyApp->can('clear_encoding') ) {
+  ok my $res = request '/root/♥';
+  is $res->code, 200, 'OK';
+  is decode_utf8($res->content), "<p>This heart literal ♥</p><p>This is heart var ♥♥♥</p>\n", 'correct body';
+  is $res->content_charset, 'UTF-8';
+} else {
+  ok 1, 'Skipping the UTF8 Tests for older installed catalyst';
+}
+
+done_testing;
+


### PR DESCRIPTION
Hi!

So two things:

1) reverse engineered the missing commit.
2) added a compatibility shim for existing test cases to work with upcoming new catalyst that does UTF8 by default.
3) added some docs around utf8 and new catalyst
4) test case to make sure this all works as we'd like with the upcoming catalyst.

Take a look and let me know what you think.  If you don't have time to deal with this module I am also happy to take co-maint and deal with it for you.  I'd only make changes related to keeping it compatible with any changes to Catalyst I want to introduce.  Thanks!  JNAP