### PR TITLE
expose more xslate initarg options

### DIFF
--- a/lib/Catalyst/View/Xslate.pm
+++ b/lib/Catalyst/View/Xslate.pm
@@ -133,6 +133,10 @@ has xslate => (
     lazy => 1, builder => '_build_xslate',
 );
 
+has [qw/line_start tag_start tag_end/] => (is=>'rw', isa=>'Str');
+has [qw/warn_handler die_handler pre_process_handler/] => (is=>'rw', isa=>'CodeRef');
+
+
 my $expose_methods_tc = subtype 'HashRef', where { $_ };
 coerce $expose_methods_tc,
   from 'ArrayRef',
@@ -169,7 +173,7 @@ sub _build_xslate {
     );
 
     # optional stuff
-    foreach my $field ( qw( input_layer syntax escape verbose suffix type ) ) {
+    foreach my $field ( qw( input_layer syntax escape verbose suffix type line_start tag_start tag_end warn_handler die_handler pre_process_handler) ) {
         if (defined(my $value = $self->$field)) {
             $args{$field} = $value;
         }
@@ -360,7 +364,20 @@ cause the previously created underlying Text::Xslate object to be cleared
 
 =head2 verbose
 
+=head2 line_start
+
+=head2 tag_start
+
+=head2 tag_end
+
+=head2 warn_handler
+
+=head2 die_handler
+
+=head2 pre_process_handler
+
 =head2 suffix
+
 
 Use this to enable TT2 compatible variable methods via Text::Xslate::Bridge::TT2 or Text::Xslate::Bridge::TT2Like
 


### PR DESCRIPTION
Just exposes a few more of the Xslate new options to the Catalyst view just in case people want or need to mess with these.  I have a use case for controlling the warn/die handlers as well as doing some preprocessing.  Let me know what you think thanks!